### PR TITLE
content: Prepare changelog for release of Leo Rover 1.9

### DIFF
--- a/docs/leo-rover/documentation/changelog.mdx
+++ b/docs/leo-rover/documentation/changelog.mdx
@@ -20,7 +20,7 @@ durability, and ease of use.
 
 <LeoRover />
 
-## Leo Rover 1.9 (coming soon Q2 2025)
+## Leo Rover 1.9
 
 - **General Changes:**
 
@@ -89,8 +89,23 @@ durability, and ease of use.
 
 :::warning
 
-Note: Versions 1.7 and below were developed at a rapid pace, leading to
-undocumented or incomplete changes.
+Support has concluded for Leo Rover 1.7 and all preceding versions. But we're
+committed to ensuring your Leo Rover remains functional and up-to-date. To
+explore pathways for upgrading or transitioning to current hardware models,
+please contact us at:
+
+<LinkButton
+  to="mailto:contact@fictionlab.pl"
+  icon="📧"
+  title="contact@fictionlab.pl"
+/>
+
+:::
+
+:::info
+
+Versions 1.7 and below were developed at a rapid pace, leading to undocumented
+or incomplete changes.
 
 :::
 


### PR DESCRIPTION
- Remove "Coming soon" from Leo 1.9
- Add notification about support cease for earlier versions of the Leo Rover (1.7 and below)