### PR TITLE
content: Add notice about ROS and LeoOS versions for Leo Rover 1.8

### DIFF
--- a/docs/leo-rover/guides/software-update.mdx
+++ b/docs/leo-rover/guides/software-update.mdx
@@ -47,6 +47,10 @@ hardware version and the associated ROS version.
   </tr>
 </table>
 
+For access to Leo Rover 1.8 documentation specific to ROS 1, navigate to the
+page's upper right corner and utilize the version selector to choose the Leo
+Rover 1.8 documentation set.
+
 :::
 
 You can find all releases of LeoOS

--- a/docs/leo-rover/guides/software-update.mdx
+++ b/docs/leo-rover/guides/software-update.mdx
@@ -21,14 +21,14 @@ Put the microSD card in the adapter and then connect it to your computer.
 
 :::info
 
-As it might be a bit confusing which Leo OS version you should install on your
+As it might be a bit confusing which LeoOS version you should install on your
 rover, here's a breakdown of the possible combinations depending on your robot
-hardware version and the associated ROS version
+hardware version and the associated ROS version.
 
 <table>
   <tr>
     <th>Robot Version</th>
-    <th>Leo OS version</th>
+    <th>LeoOS version</th>
     <th>ROS Version</th>
   </tr>
   <tr>

--- a/docs/leo-rover/guides/software-update.mdx
+++ b/docs/leo-rover/guides/software-update.mdx
@@ -19,6 +19,36 @@ Put the microSD card in the adapter and then connect it to your computer.
 
 ### Download the newest LeoOS image
 
+:::info
+
+As it might be a bit confusing which Leo OS version you should install on your
+rover, here's a breakdown of the possible combinations depending on your robot
+hardware version and the associated ROS version
+
+<table>
+  <tr>
+    <th>Robot Version</th>
+    <th>Leo OS version</th>
+    <th>ROS Version</th>
+  </tr>
+  <tr>
+    <td rowspan="2">Leo 1.8</td>
+    <td>1.x.x</td>
+    <td>ROS 1</td>
+  </tr>
+  <tr>
+    <td>2.x.x</td>
+    <td>ROS 2</td>
+  </tr>
+  <tr>
+    <td>Leo 1.9</td>
+    <td> 2.x.x</td>
+    <td>ROS 2</td>
+  </tr>
+</table>
+
+:::
+
 You can find all releases of LeoOS
 [here](https://github.com/LeoRover/leo_os/releases). Choose the newest one and
 download the image (.img.xz file) you want. We recommend the `full` version. The

--- a/leo-rover_versioned_docs/version-1.8/advanced-guides/_advanced-guides-ROS2-info.mdx
+++ b/leo-rover_versioned_docs/version-1.8/advanced-guides/_advanced-guides-ROS2-info.mdx
@@ -1,0 +1,6 @@
+:::note
+
+The advanced guides are exclusively for ROS 1. We are actively working on
+updating these guides to also support ROS 2.
+
+:::

--- a/leo-rover_versioned_docs/version-1.8/advanced-guides/autonomous-navigation.mdx
+++ b/leo-rover_versioned_docs/version-1.8/advanced-guides/autonomous-navigation.mdx
@@ -8,6 +8,9 @@ description: >-
 ---
 
 import LiteYouTubeEmbed from 'react-lite-youtube-embed';
+import ROS2info from './_advanced-guides-ROS2-info.mdx';
+
+<ROS2info />
 
 In this tutorial, we will show you how to perform SLAM (Simultaneous
 localization and mapping) and autonomous navigation on Leo Rover equipped with

--- a/leo-rover_versioned_docs/version-1.8/advanced-guides/connecting-many-rovers-together.mdx
+++ b/leo-rover_versioned_docs/version-1.8/advanced-guides/connecting-many-rovers-together.mdx
@@ -7,6 +7,10 @@ description: >-
   and see each other using ROS namespaces and a single ROS master.
 ---
 
+import ROS2info from './_advanced-guides-ROS2-info.mdx';
+
+<ROS2info />
+
 In this tutorial, we will show you how to configure many rovers in one network,
 so that they will see each other and will communicate.
 

--- a/leo-rover_versioned_docs/version-1.8/advanced-guides/install-ros-on-your-computer.mdx
+++ b/leo-rover_versioned_docs/version-1.8/advanced-guides/install-ros-on-your-computer.mdx
@@ -9,6 +9,9 @@ description: >-
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import ROS2info from './_advanced-guides-ROS2-info.mdx';
+
+<ROS2info />
 
 Having ROS on your host machine has many advantages. First of all, it allows you
 to communicate with nodes running on your Leo Rover, so it is easier to

--- a/leo-rover_versioned_docs/version-1.8/advanced-guides/joystick.mdx
+++ b/leo-rover_versioned_docs/version-1.8/advanced-guides/joystick.mdx
@@ -7,6 +7,10 @@ description: >-
   packages, mapping axes and buttons.
 ---
 
+import ROS2info from './_advanced-guides-ROS2-info.mdx';
+
+<ROS2info />
+
 In this example, we will create a simple package that will let you control Leo
 Rover using a joystick connected to your computer.
 

--- a/leo-rover_versioned_docs/version-1.8/advanced-guides/ros-2-support.mdx
+++ b/leo-rover_versioned_docs/version-1.8/advanced-guides/ros-2-support.mdx
@@ -7,6 +7,10 @@ description: >-
   image. Find out about the necessary firmware updates and configuration steps.
 ---
 
+import ROS2info from './_advanced-guides-ROS2-info.mdx';
+
+<ROS2info />
+
 :::warning
 
 ROS 2 support on Leo Rover is still experimental. Expect missing features,

--- a/leo-rover_versioned_docs/version-1.8/advanced-guides/ros-development.mdx
+++ b/leo-rover_versioned_docs/version-1.8/advanced-guides/ros-development.mdx
@@ -7,6 +7,10 @@ description: >-
   additional functionalities, building ROS packages and more.
 ---
 
+import ROS2info from './_advanced-guides-ROS2-info.mdx';
+
+<ROS2info />
+
 > The Robot Operating System (ROS) is a flexible framework for writing robot
 > software. It is a collection of tools, libraries, and conventions that aim to
 > simplify the task of creating complex and robust robot behavior across a wide

--- a/leo-rover_versioned_docs/version-1.8/advanced-guides/ros-graph-in-rqt.mdx
+++ b/leo-rover_versioned_docs/version-1.8/advanced-guides/ros-graph-in-rqt.mdx
@@ -7,6 +7,10 @@ description: >-
   tool for ROS debugging and visualization.
 ---
 
+import ROS2info from './_advanced-guides-ROS2-info.mdx';
+
+<ROS2info />
+
 This tutorial is devoted to introspecting the ROS computation graph in RQT. But
 what is the rqt graph in the first place?
 

--- a/leo-rover_versioned_docs/version-1.8/advanced-guides/rviz.mdx
+++ b/leo-rover_versioned_docs/version-1.8/advanced-guides/rviz.mdx
@@ -7,6 +7,10 @@ description: >-
   for setting up the necessary packages and launching the visualization.
 ---
 
+import ROS2info from './_advanced-guides-ROS2-info.mdx';
+
+<ROS2info />
+
 ## Prerequisites
 
 <LinkButton docId="advanced-guides/ros-development" />

--- a/leo-rover_versioned_docs/version-1.8/guides/firmware-update.mdx
+++ b/leo-rover_versioned_docs/version-1.8/guides/firmware-update.mdx
@@ -7,6 +7,9 @@ description: >-
   extra cables. Step-by-step guide.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Prerequisites
 
 <LinkButton docId="guides/ssh" />
@@ -25,9 +28,20 @@ sudo apt update && sudo apt upgrade
 
 And then, run the update script by typing:
 
-```bash
-rosrun leo_fw update
-```
+<Tabs groupId="update">
+  <TabItem value="ros1" label="ROS 1">
+    ```bash
+    rosrun leo_fw update
+    ```
+
+  </TabItem>
+  <TabItem value="ros2" label="ROS 2">
+    ```bash
+    ros2 run leo_fw update
+    ```
+    
+  </TabItem>
+</Tabs>
 
 The script will guide you through the flashing process.
 

--- a/leo-rover_versioned_docs/version-1.8/guides/imu-calibration.mdx
+++ b/leo-rover_versioned_docs/version-1.8/guides/imu-calibration.mdx
@@ -7,6 +7,15 @@ description: >-
   issues and get accurate sensor data.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+:::info
+
+Since LeoOS 2.0 version you don't need to calibrate the IMU on the rover.
+
+:::
+
 ## Prerequisites
 
 <LinkButton docId="guides/connect-to-rover-ap" />

--- a/leo-rover_versioned_docs/version-1.8/guides/imu-calibration.mdx
+++ b/leo-rover_versioned_docs/version-1.8/guides/imu-calibration.mdx
@@ -10,7 +10,7 @@ description: >-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::info
+:::tip
 
 Since LeoOS 2.0 version you don't need to calibrate the IMU on the rover.
 

--- a/leo-rover_versioned_docs/version-1.8/guides/remote-desktop.mdx
+++ b/leo-rover_versioned_docs/version-1.8/guides/remote-desktop.mdx
@@ -15,6 +15,12 @@ environment installed, as well as an RDP (Microsoft Remote Desktop Protocol)
 server. This allows you to remotely control a desktop session on your Rover from
 your computer.
 
+Firstly, you will have to connect to the Rover's network:
+
+<LinkButton docId="guides/connect-to-rover-ap" />
+
+<Tabs groupId='ROS-version'>
+<TabItem value='ros1' label='ROS1'>
 <Tabs groupId='OS'>
     <TabItem value='windows' label='Windows'>
     
@@ -161,4 +167,22 @@ your computer.
 
     </TabItem>
 
+</Tabs>
+</TabItem>
+<TabItem value='ros2' label='ROS2'>
+Now, to connect to the robot's desktop you have to install and open
+[TigerVNC viewer](https://tigervnc.org/)
+
+Type `10.0.0.1` in the **VNC server** field and click **Connect**.
+
+<ImageZoom
+  src="/img/robots/leo/guides/remote-desktop/tigervnc.webp"
+  alt="Remote Desktop Connection app"
+  width="407"
+  height="253"
+  figStyle={{
+    width: 400,
+  }}
+/>
+</TabItem>
 </Tabs>

--- a/leo-rover_versioned_docs/version-1.8/guides/remote-desktop.mdx
+++ b/leo-rover_versioned_docs/version-1.8/guides/remote-desktop.mdx
@@ -19,8 +19,8 @@ Firstly, you will have to connect to the Rover's network:
 
 <LinkButton docId="guides/connect-to-rover-ap" />
 
-<Tabs groupId='ROS-version'>
-<TabItem value='ros1' label='ROS1'>
+<Tabs groupId='leoOS-version'>
+<TabItem value='leoOS1' label='LeoOS 1.x'>
 <Tabs groupId='OS'>
     <TabItem value='windows' label='Windows'>
     
@@ -169,7 +169,7 @@ Firstly, you will have to connect to the Rover's network:
 
 </Tabs>
 </TabItem>
-<TabItem value='ros2' label='ROS2'>
+<TabItem value='leoOS2' label='LeoOS 2.x'>
 Now, to connect to the robot's desktop you have to install and open
 [TigerVNC viewer](https://tigervnc.org/)
 

--- a/leo-rover_versioned_docs/version-1.8/guides/software-update.mdx
+++ b/leo-rover_versioned_docs/version-1.8/guides/software-update.mdx
@@ -19,6 +19,39 @@ Put the microSD card in the adapter and then connect it to your computer.
 
 ### Download the newest LeoOS image
 
+:::info
+
+As it might be a bit confusing which Leo OS version you should install on your
+rover, here's a breakdown of the possible combinations depending on your robot
+hardware version and the associated ROS version
+
+<table>
+  <tr>
+    <th>Robot Version</th>
+    <th>Leo OS version</th>
+    <th>ROS Version</th>
+  </tr>
+  <tr>
+    <td rowspan="2">Leo 1.8</td>
+    <td>1.x.x</td>
+    <td>ROS 1</td>
+  </tr>
+  <tr>
+    <td>2.x.x</td>
+    <td>ROS 2</td>
+  </tr>
+  <tr>
+    <td>Leo 1.9</td>
+    <td> 2.x.x</td>
+    <td>ROS 2</td>
+  </tr>
+</table>
+The system you choose determines which integration steps and documentation
+version apply to your setup (for Leo 1.8, some guides include both ROS 1 and ROS
+2 instructions—make sure to select the correct option where applicable).{' '}
+
+:::
+
 You can find all releases of LeoOS
 [here](https://github.com/LeoRover/leo_os/releases). Choose the newest one and
 download the image (.img.xz file) you want. We recommend the `full` version. The

--- a/leo-rover_versioned_docs/version-1.8/guides/software-update.mdx
+++ b/leo-rover_versioned_docs/version-1.8/guides/software-update.mdx
@@ -46,9 +46,9 @@ hardware version and the associated ROS version
     <td>ROS 2</td>
   </tr>
 </table>
-The system you choose determines which integration steps and documentation
-version apply to your setup (for Leo 1.8, some guides include both ROS 1 and ROS
-2 instructions—make sure to select the correct option where applicable).{' '}
+The system you choose determines which integrations and documentation versions
+apply to your setup (for Leo 1.8, some guides include both ROS 1 and ROS 2
+instructions - make sure to select the correct option where applicable).
 
 :::
 

--- a/leo-rover_versioned_docs/version-1.8/guides/software-update.mdx
+++ b/leo-rover_versioned_docs/version-1.8/guides/software-update.mdx
@@ -21,14 +21,14 @@ Put the microSD card in the adapter and then connect it to your computer.
 
 :::info
 
-As it might be a bit confusing which Leo OS version you should install on your
+As it might be a bit confusing which LeoOS version you should install on your
 rover, here's a breakdown of the possible combinations depending on your robot
-hardware version and the associated ROS version
+hardware version and the associated ROS version.
 
 <table>
   <tr>
     <th>Robot Version</th>
-    <th>Leo OS version</th>
+    <th>LeoOS version</th>
     <th>ROS Version</th>
   </tr>
   <tr>

--- a/leo-rover_versioned_docs/version-1.8/leo-examples/_examples-ROS2-info.mdx
+++ b/leo-rover_versioned_docs/version-1.8/leo-examples/_examples-ROS2-info.mdx
@@ -1,0 +1,6 @@
+:::note
+
+The Leo Examples are currently only compatible with ROS 1. We are actively
+working on updating them to include support for ROS 2.
+
+:::

--- a/leo-rover_versioned_docs/version-1.8/leo-examples/follow-artag.mdx
+++ b/leo-rover_versioned_docs/version-1.8/leo-examples/follow-artag.mdx
@@ -18,6 +18,9 @@ description: >-
 ---
 
 import LiteYouTubeEmbed from 'react-lite-youtube-embed';
+import ROS2info from './_examples-ROS2-info.mdx';
+
+<ROS2info />
 
 An ARTag follower example for a stock Leo Rover
 

--- a/leo-rover_versioned_docs/version-1.8/leo-examples/line-follower.mdx
+++ b/leo-rover_versioned_docs/version-1.8/leo-examples/line-follower.mdx
@@ -20,6 +20,9 @@ description: >-
 ---
 
 import LiteYouTubeEmbed from 'react-lite-youtube-embed';
+import ROS2info from './_examples-ROS2-info.mdx';
+
+<ROS2info />
 
 A line follower example for stock Leo Rover
 

--- a/leo-rover_versioned_docs/version-1.8/leo-examples/object-detection.mdx
+++ b/leo-rover_versioned_docs/version-1.8/leo-examples/object-detection.mdx
@@ -20,6 +20,9 @@ description: >-
 ---
 
 import LiteYouTubeEmbed from 'react-lite-youtube-embed';
+import ROS2info from './_examples-ROS2-info.mdx';
+
+<ROS2info />
 
 An object detection example for stock Leo Rover
 


### PR DESCRIPTION
* firmware update: added tabs for ros command
* software update 1.8: added table with OS versions breakdown and hints
* software update 1.9: added table with OS versions breakdown
* remote desktop: added tabs for ROS1 and ROS2 
* imu calibration: added info about redundancy of calibration for OS versions 2.x.x