### PR TITLE
content: Add captions to all part images in assembly manuals

### DIFF
--- a/docs/leo-rover/manuals/back-front-covers.mdx
+++ b/docs/leo-rover/manuals/back-front-covers.mdx
@@ -263,7 +263,7 @@ figStyle={{
     }}
     width="1500"
     height="1500"
-    caption='Battery cover'
+    caption="Battery cover"
   />
 </FlexTableItem>
 
@@ -548,7 +548,7 @@ figStyle={{
       }}
       width="1500"
       height="1500"
-      caption='Step 1 assembly'
+      caption="Step 1 assembly"
     />
   </FlexTableItem>
 </FlexTable>
@@ -634,7 +634,7 @@ figStyle={{
     }}
     width="1500"
     height="1500"
-    caption='Addon metal plate'
+    caption="Addon metal plate"
   />
 </FlexTableItem>
 
@@ -778,7 +778,7 @@ figStyle={{
     }}
     width="1500"
     height="1500"
-    caption='Mounting plate'
+    caption="Mounting plate"
   />
 </FlexTableItem>
 

--- a/docs/leo-rover/manuals/back-front-covers.mdx
+++ b/docs/leo-rover/manuals/back-front-covers.mdx
@@ -36,13 +36,14 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
 
   <ThemedImageZoom
     loading="eager"
-    alt="loctite"
+    alt="Flat Screwdriver"
     sources={{
       light: useBaseUrl('/img/robots/leo/manuals/tools/screwdriver_black.webp'),
       dark: useBaseUrl('/img/robots/leo/manuals/tools/screwdriver_white.webp'),
     }}
     width="1500"
     height="1500"
+    caption='Flat Screwdriver'
 
 figStyle={{
     width: 400,
@@ -69,6 +70,7 @@ figStyle={{
             }}
             width="1500"
             height="1500"
+            caption='Battery box cover'
           />
   </FlexTableItem>
 
@@ -108,6 +110,7 @@ figStyle={{
             }}
             width="1500"
             height="1500"
+            caption='Battery cable'
           />
 
   </FlexTableItem>
@@ -157,13 +160,14 @@ figStyle={{
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Button set"
+            alt="Button"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/battery-and-covers/Button_set_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/battery-and-covers/Button_set_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Button'
           />
   </FlexTableItem>
 
@@ -180,6 +184,7 @@ figStyle={{
             }}
             width="1500"
             height="1500"
+            caption='Battery box'
           />
   </FlexTableItem>
 </FlexTable>
@@ -235,6 +240,7 @@ figStyle={{
             }}
             width="1500"
             height="1500"
+            caption='Battery metal plate'
           />
   </FlexTableItem>
 
@@ -257,6 +263,7 @@ figStyle={{
     }}
     width="1500"
     height="1500"
+    caption='Battery cover'
   />
 </FlexTableItem>
 
@@ -361,13 +368,14 @@ figStyle={{
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="Step 2 assembly"
+    alt="Step 3 assembly"
     sources={{
       light: useBaseUrl('/img/robots/leo/manuals/battery-and-covers/Battery_box_with_button_black.webp'),
       dark: useBaseUrl('/img/robots/leo/manuals/battery-and-covers/Battery_box_with_button_white.webp'),
     }}
     width="1500"
     height="1500"
+    caption='Step 3 assembly'
   />
 </FlexTableItem>
 
@@ -441,6 +449,7 @@ figStyle={{
             }}
             width="1500"
             height="1500"
+            caption='Battery pack'
           />
   </FlexTableItem>
 
@@ -451,13 +460,14 @@ figStyle={{
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Foam"
+            alt="Battery foam"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/battery-and-covers/foam_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/battery-and-covers/foam_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Battery foam'
           />
   </FlexTableItem>
 </FlexTable>
@@ -527,7 +537,7 @@ figStyle={{
     mobileColumns={2}
   >
     <ThemedImageZoom
-      alt="Step 4 assembly"
+      alt="Step 1 assembly"
       sources={{
         light: useBaseUrl(
           '/img/robots/leo/manuals/battery-and-covers/Top_with_wiring_black.webp',
@@ -538,6 +548,7 @@ figStyle={{
       }}
       width="1500"
       height="1500"
+      caption='Step 1 assembly'
     />
   </FlexTableItem>
 </FlexTable>
@@ -591,13 +602,14 @@ figStyle={{
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Addon quarter cover"
+            alt="Addon cover"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/battery-and-covers/Addon_qrt_cover_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/battery-and-covers/Addon_qrt_cover_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Addon cover'
           />
   </FlexTableItem>
 
@@ -622,6 +634,7 @@ figStyle={{
     }}
     width="1500"
     height="1500"
+    caption='Addon metal plate'
   />
 </FlexTableItem>
 
@@ -740,6 +753,7 @@ figStyle={{
             }}
             width="1500"
             height="1500"
+            caption='Front cover'
           />
   </FlexTableItem>
 
@@ -764,6 +778,7 @@ figStyle={{
     }}
     width="1500"
     height="1500"
+    caption='Mounting plate'
   />
 </FlexTableItem>
 

--- a/docs/leo-rover/manuals/combining-subassemblies.mdx
+++ b/docs/leo-rover/manuals/combining-subassemblies.mdx
@@ -395,14 +395,14 @@ Slide the front cover over the differential bar.\
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Task 1 - motor assembly"
+            alt="Task 1 - 4x motor assembly"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/full-assembly/wheels_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/full-assembly/wheels_white.webp'),
             }}
             width="1500"
             height="1500"
-            caption='Task 1 - motor assembly'
+            caption='Task 1 - 4x motor assembly'
           />
   </FlexTableItem>
 

--- a/docs/leo-rover/manuals/combining-subassemblies.mdx
+++ b/docs/leo-rover/manuals/combining-subassemblies.mdx
@@ -46,13 +46,14 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
     mobileColumns={2}>
       <ThemedImageZoom
             loading="eager"
-            alt="Front cover"
+            alt="Task 4 - Front cover assembly"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/full-assembly/front_cover_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/full-assembly/front_cover_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Task 4 - front cover assembly'
           />
   </FlexTableItem>
 
@@ -63,13 +64,14 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
     }}mobileColumns={2}>
       <ThemedImageZoom
             loading="eager"
-            alt="Task 2 assembly"
+            alt="Task 3 - frame assembly"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/full-assembly/raw_frame_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/full-assembly/raw_frame_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Task 3 - frame assembly'
           />
   </FlexTableItem>
 </FlexTable>
@@ -127,13 +129,14 @@ Slide the front cover over the differential bar.\
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="MEB assembly"
+            alt="Task 2 - MEB assembly"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/full-assembly/MEB_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/full-assembly/MEB_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Task 2 - MEB assembly'
           />
   </FlexTableItem>
 
@@ -208,13 +211,14 @@ Slide the front cover over the differential bar.\
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Battery quarter"
+            alt="Task 4 - battery assembly"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/full-assembly/battery_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/full-assembly/battery_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Task 4 - battery assembly'
           />
   </FlexTableItem>
 
@@ -282,7 +286,7 @@ Slide the front cover over the differential bar.\
     mobileColumns={2}
   >
     <ThemedImageZoom
-      alt="Step 3 assembly"
+      alt="MEB - Battery cable"
       sources={{
         light: useBaseUrl(
           '/img/robots/leo/manuals/full-assembly/MEB_battery_cable_black.webp',
@@ -293,6 +297,7 @@ Slide the front cover over the differential bar.\
       }}
       width="1500"
       height="1500"
+      caption="MEB - Battery cable"
     />
   </FlexTableItem>
 </FlexTable>
@@ -326,13 +331,14 @@ Slide the front cover over the differential bar.\
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Addon quarter"
+            alt="Task 4 - addon quarter assembly"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/full-assembly/addon_qrt_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/full-assembly/addon_qrt_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Task 4 - addon quarter assembly'
           />
   </FlexTableItem>
 
@@ -389,13 +395,14 @@ Slide the front cover over the differential bar.\
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Step 4 assembly"
+            alt="Task 1 - motor assembly"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/full-assembly/wheels_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/full-assembly/wheels_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Task 1 - motor assembly'
           />
   </FlexTableItem>
 
@@ -528,6 +535,7 @@ are connected to the upper sockets.
       }}
       width="1500"
       height="1500"
+      caption="Zip ties"
     />
   </FlexTableItem>
 </FlexTable>
@@ -576,7 +584,7 @@ are connected to the upper sockets.
     mobileColumns={2}
   >
     <ThemedImageZoom
-      alt="Step 4 assembly"
+      alt="V-slot clips"
       sources={{
         light: useBaseUrl(
           '/img/robots/leo/manuals/full-assembly/clips_black.webp',
@@ -587,6 +595,7 @@ are connected to the upper sockets.
       }}
       width="1500"
       height="1500"
+      caption="V-slot clips"
     />
   </FlexTableItem>
 </FlexTable>
@@ -675,6 +684,7 @@ beam grooves to secure the cables.
             }}
             width="1500"
             height="1500"
+            caption='MEB cover'
           />
   </FlexTableItem>
 <FlexTableItem
@@ -692,6 +702,7 @@ beam grooves to secure the cables.
     }}
     width="1500"
     height="1500"
+    caption='MEB Cover seal'
   />
 </FlexTableItem>
 
@@ -766,7 +777,7 @@ beam grooves to secure the cables.
     mobileColumns={2}
   >
     <ThemedImageZoom
-      alt="Antenna"
+      alt="WiFi antenna"
       sources={{
         light: useBaseUrl(
           '/img/robots/leo/manuals/full-assembly/antenna_black.webp',
@@ -777,6 +788,7 @@ beam grooves to secure the cables.
       }}
       width="1500"
       height="1500"
+      caption="WiFi antenna"
     />
   </FlexTableItem>
 </FlexTable>
@@ -825,7 +837,7 @@ beam grooves to secure the cables.
     mobileColumns={2}
   >
     <ThemedImageZoom
-      alt="usb plug mount"
+      alt="USB plug mount"
       sources={{
         light: useBaseUrl(
           '/img/robots/leo/manuals/full-assembly/USB_Plug_mount_black.webp',
@@ -836,6 +848,7 @@ beam grooves to secure the cables.
       }}
       width="1500"
       height="1500"
+      caption='USB plug mount'
     />
   </FlexTableItem>
 
@@ -919,6 +932,7 @@ beam grooves to secure the cables.
       }}
       width="1500"
       height="1500"
+      caption="USB plug"
     />
   </FlexTableItem>
   <FlexTableItem

--- a/docs/leo-rover/manuals/frame-and-suspension.mdx
+++ b/docs/leo-rover/manuals/frame-and-suspension.mdx
@@ -27,8 +27,8 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
       '/img/robots/leo/manuals/tools/toolbox_1.9_frame_white.webp',
     ),
   }}
-  width="1480"
-  height="2200"
+  width="3000"
+  height="2121"
   figStyle={{
     width: 600,
   }}
@@ -41,8 +41,8 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
     light: useBaseUrl('/img/robots/leo/manuals/tools/layer-5-1.9-black.webp'),
     dark: useBaseUrl('/img/robots/leo/manuals/tools/layer-5-1.9-white.webp'),
   }}
-  width="1480"
-  height="2200"
+  width="3000"
+  height="2121"
   figStyle={{
     width: 600,
   }}
@@ -67,6 +67,7 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
             }}
             width="1500"
             height="1500"
+            caption='Suspension mounts'
           />
   </FlexTableItem>
 
@@ -78,7 +79,7 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="igus pushrod"
+    alt="Pushrod"
     sources={{
       light: useBaseUrl(
         '/img/robots/leo/manuals/frame/igus_pushrod_black.webp',
@@ -87,6 +88,7 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
     }}
     width="1500"
     height="1500"
+    caption="Pushrod"
   />
 </FlexTableItem>
 
@@ -184,13 +186,14 @@ Repeat until you have 2 suspension mounts.
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Rocker beams"
+            alt="V-slot rocker beams"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/frame/V-slot_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/frame/V-slot_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='V-slot rocker beams'
           />
   </FlexTableItem>
 
@@ -202,7 +205,7 @@ Repeat until you have 2 suspension mounts.
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="Right rocker arm"
+    alt="Right rocker arms"
     sources={{
       light: useBaseUrl(
         '/img/robots/leo/manuals/frame/Right_rocker_arm_black.webp',
@@ -213,6 +216,7 @@ Repeat until you have 2 suspension mounts.
     }}
     width="1500"
     height="1500"
+    caption="Right rocker arms"
   />
 </FlexTableItem>
 
@@ -224,7 +228,7 @@ Repeat until you have 2 suspension mounts.
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="Left rocker arm"
+    alt="Left rocker arms"
     sources={{
       light: useBaseUrl(
         '/img/robots/leo/manuals/frame/Left_rocker_arm_black.webp',
@@ -235,6 +239,7 @@ Repeat until you have 2 suspension mounts.
     }}
     width="1500"
     height="1500"
+    caption="Left rocker arms"
   />
 </FlexTableItem>
 
@@ -329,6 +334,7 @@ Repeat the steps until you have 2 suspension mounts.
             }}
             width="1500"
             height="1500"
+            caption='Main frame'
           />
   </FlexTableItem>
 
@@ -376,13 +382,14 @@ Repeat the steps until you have 2 suspension mounts.
       width: '30%'
     }}mobileColumns={2}>
       <ThemedImageZoom
-            alt="3x M4x10 torx screw"
+            alt="Bearing supports"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/frame/bearing_support_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/frame/bearing_support_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Bearing supports'
           />
   </FlexTableItem>
 </FlexTable>
@@ -436,6 +443,7 @@ Repeat the steps until you have 2 suspension mounts.
             }}
             width="1500"
             height="1500"
+            caption='Differential beam support plate'
           />
   </FlexTableItem>
 <FlexTableItem
@@ -521,13 +529,14 @@ Repeat the steps until you have 2 suspension mounts.
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="differential beam"
+            alt="Differential beam"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/frame/diff_beam_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/frame/diff_beam_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Differential beam'
           />
   </FlexTableItem>
 
@@ -639,13 +648,14 @@ move without excess play and resistance.
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Step 3 assembly"
+            alt="Rear frame"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/frame/rear_frame_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/frame/rear_frame_white.webp'),
             }}
             width="2300"
             height="2400"
+            caption='Rear frame'
           />
   </FlexTableItem>
 
@@ -708,13 +718,14 @@ move without excess play and resistance.
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="V-slot mounts"
+            alt="Step 1 assemblies"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/frame/suspension_mounts_2_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/frame/suspension_mounts_2_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Step 1 assemblies'
           />
   </FlexTableItem>
 
@@ -911,13 +922,14 @@ can move without excess play and resistance.
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Suspension beams"
+            alt="Step 2 assemblies"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/frame/rockers_2_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/frame/rockers_2_white.webp'),
             }}
             width="2300"
             height="2400"
+            caption='Step 2 assemblies'
           />
   </FlexTableItem>
 
@@ -986,8 +998,8 @@ can move without excess play and resistance.
       '/img/robots/leo/manuals/frame/D_suspension_beams_white.webp',
     ),
   }}
-  width="1480"
-  height="2200"
+  width="3000"
+  height="2121"
   figStyle={{
     width: 600,
   }}

--- a/docs/leo-rover/manuals/frame-and-suspension.mdx
+++ b/docs/leo-rover/manuals/frame-and-suspension.mdx
@@ -60,14 +60,14 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Suspension mounts"
+            alt="2x Suspension mount"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/frame/suspension_mounts_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/frame/suspension_mounts_white.webp'),
             }}
             width="1500"
             height="1500"
-            caption='Suspension mounts'
+            caption='2x Suspension mount'
           />
   </FlexTableItem>
 
@@ -79,7 +79,7 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="Pushrod"
+    alt="2x Pushrod"
     sources={{
       light: useBaseUrl(
         '/img/robots/leo/manuals/frame/igus_pushrod_black.webp',
@@ -88,7 +88,7 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
     }}
     width="1500"
     height="1500"
-    caption="Pushrod"
+    caption="2x Pushrod"
   />
 </FlexTableItem>
 
@@ -186,14 +186,14 @@ Repeat until you have 2 suspension mounts.
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="V-slot rocker beams"
+            alt="2x V-slot rocker beam"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/frame/V-slot_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/frame/V-slot_white.webp'),
             }}
             width="1500"
             height="1500"
-            caption='V-slot rocker beams'
+            caption='2x V-slot rocker beam'
           />
   </FlexTableItem>
 
@@ -205,7 +205,7 @@ Repeat until you have 2 suspension mounts.
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="Right rocker arms"
+    alt="2x Right rocker arm"
     sources={{
       light: useBaseUrl(
         '/img/robots/leo/manuals/frame/Right_rocker_arm_black.webp',
@@ -216,7 +216,7 @@ Repeat until you have 2 suspension mounts.
     }}
     width="1500"
     height="1500"
-    caption="Right rocker arms"
+    caption="2x Right rocker arm"
   />
 </FlexTableItem>
 
@@ -228,7 +228,7 @@ Repeat until you have 2 suspension mounts.
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="Left rocker arms"
+    alt="2x Left rocker arm"
     sources={{
       light: useBaseUrl(
         '/img/robots/leo/manuals/frame/Left_rocker_arm_black.webp',
@@ -239,11 +239,9 @@ Repeat until you have 2 suspension mounts.
     }}
     width="1500"
     height="1500"
-    caption="Left rocker arms"
+    caption="2x Left rocker arm"
   />
 </FlexTableItem>
-
-{' '}
 
 <FlexTableItem
   style={{
@@ -382,14 +380,14 @@ Repeat the steps until you have 2 suspension mounts.
       width: '30%'
     }}mobileColumns={2}>
       <ThemedImageZoom
-            alt="Bearing supports"
+            alt="2x Bearing support"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/frame/bearing_support_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/frame/bearing_support_white.webp'),
             }}
             width="1500"
             height="1500"
-            caption='Bearing supports'
+            caption='2x Bearing support'
           />
   </FlexTableItem>
 </FlexTable>
@@ -718,14 +716,14 @@ move without excess play and resistance.
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Step 1 assemblies"
+            alt="Step 1 assembly"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/frame/suspension_mounts_2_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/frame/suspension_mounts_2_white.webp'),
             }}
             width="1500"
             height="1500"
-            caption='Step 1 assemblies'
+            caption='Step 1 assembly'
           />
   </FlexTableItem>
 
@@ -922,14 +920,14 @@ can move without excess play and resistance.
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Step 2 assemblies"
+            alt="Step 2 assembly"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/frame/rockers_2_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/frame/rockers_2_white.webp'),
             }}
             width="2300"
             height="2400"
-            caption='Step 2 assemblies'
+            caption='Step 2 assembly'
           />
   </FlexTableItem>
 

--- a/docs/leo-rover/manuals/frame-and-suspension.mdx
+++ b/docs/leo-rover/manuals/frame-and-suspension.mdx
@@ -56,7 +56,7 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
   
   <FlexTableItem
     style={{
-      width: '40%'
+      width: '30%'
     }}
     mobileColumns={2}>
       <ThemedImageZoom
@@ -73,7 +73,7 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
 <FlexTableItem
   style={{
     textAlign: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -93,7 +93,7 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
 <FlexTableItem
   style={{
     textAlign: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -114,7 +114,7 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
    <FlexTableItem
     style={{
       textAlign: 'center',
-      width: '40%'
+      width: '30%'
     }}mobileColumns={2}>
       <ThemedImageZoom
             alt="2x M6 nut"
@@ -180,7 +180,7 @@ Repeat until you have 2 suspension mounts.
   
   <FlexTableItem
     style={{
-      width: '40%'
+      width: '30%'
     }}
     mobileColumns={2}>
       <ThemedImageZoom
@@ -197,7 +197,7 @@ Repeat until you have 2 suspension mounts.
 <FlexTableItem
   style={{
     textAlign: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -318,7 +318,7 @@ Repeat the steps until you have 2 suspension mounts.
   
   <FlexTableItem
     style={{
-      width: '40%'
+      width: '30%'
     }}
     mobileColumns={2}>
       <ThemedImageZoom
@@ -335,7 +335,7 @@ Repeat the steps until you have 2 suspension mounts.
 <FlexTableItem
   style={{
     textAlign: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -354,7 +354,7 @@ Repeat the steps until you have 2 suspension mounts.
 <FlexTableItem
   style={{
     textAlign: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -373,7 +373,7 @@ Repeat the steps until you have 2 suspension mounts.
    <FlexTableItem
     style={{
       textAlign: 'center',
-      width: '40%'
+      width: '30%'
     }}mobileColumns={2}>
       <ThemedImageZoom
             alt="3x M4x10 torx screw"
@@ -517,7 +517,7 @@ Repeat the steps until you have 2 suspension mounts.
   <FlexTableItem
     style={{
       textAlign: 'center',
-      width: '40%'
+      width: '30%'
     }}
     mobileColumns={2}>
       <ThemedImageZoom
@@ -534,7 +534,7 @@ Repeat the steps until you have 2 suspension mounts.
 <FlexTableItem
   style={{
     textAlign: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -557,7 +557,7 @@ Repeat the steps until you have 2 suspension mounts.
 <FlexTableItem
   style={{
     textAlign: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -576,7 +576,7 @@ Repeat the steps until you have 2 suspension mounts.
 <FlexTableItem
   style={{
     textAlign: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -635,7 +635,7 @@ move without excess play and resistance.
   
   <FlexTableItem
     style={{
-      width: '40%'
+      width: '30%'
     }}
     mobileColumns={2}>
       <ThemedImageZoom
@@ -652,7 +652,7 @@ move without excess play and resistance.
 <FlexTableItem
   style={{
     textAlign: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -704,7 +704,7 @@ move without excess play and resistance.
   
   <FlexTableItem
     style={{
-      width: '40%'
+      width: '30%'
     }}
     mobileColumns={2}>
       <ThemedImageZoom
@@ -721,7 +721,7 @@ move without excess play and resistance.
 <FlexTableItem
   style={{
     textAlign: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -740,7 +740,7 @@ move without excess play and resistance.
 <FlexTableItem
   style={{
     textAlign: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -759,7 +759,7 @@ move without excess play and resistance.
     <FlexTableItem
     style={{
       textAlign: 'center',
-      width: '40%'
+      width: '30%'
     }}mobileColumns={2}>
       <ThemedImageZoom
             alt="2x Nut M6"
@@ -827,7 +827,7 @@ can move without excess play and resistance.
   
   <FlexTableItem
     style={{
-      width: '40%'
+      width: '30%'
     }}
     mobileColumns={2}>
       <ThemedImageZoom
@@ -845,7 +845,7 @@ can move without excess play and resistance.
 <FlexTableItem
   style={{
     textAlign: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >

--- a/docs/leo-rover/manuals/main-electronics-box-meb.mdx
+++ b/docs/leo-rover/manuals/main-electronics-box-meb.mdx
@@ -291,7 +291,7 @@ down on the <span style={{ color: '#bf7b2c' }}> **connector handle**</span>.
       width: '30%'
     }}mobileColumns={2}>
       <ThemedImageZoom
-            alt="Rasperry Pi case bottom"
+            alt="Raspberry Pi case bottom"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/meb/Case_bottom_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/meb/Case_bottom_white.webp'),

--- a/docs/leo-rover/manuals/main-electronics-box-meb.mdx
+++ b/docs/leo-rover/manuals/main-electronics-box-meb.mdx
@@ -137,14 +137,14 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Raspberry pi 5"
+            alt="Raspberry Pi 5"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/meb/RPI_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/meb/RPI_white.webp'),
             }}
             width="1500"
             height="1500"
-            caption='Raspberry pi 5'
+            caption='Raspberry Pi 5'
           />
   </FlexTableItem>
 
@@ -348,14 +348,14 @@ Remove tape from heatpads before closing the case.
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Leo Core"
+            alt="LeoCore"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/meb/Leo_Core_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/meb/Leo_Core_white.webp'),
             }}
             width="1500"
             height="1500"
-            caption='Leo Core'
+            caption='LeoCore'
           />
   </FlexTableItem>
 
@@ -1275,7 +1275,7 @@ prevent them from loosening over time.
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="USB socket seal"
+    alt="USB-C socket seal"
     sources={{
       light: useBaseUrl(
         '/img/robots/leo/manuals/meb/USB_socket_seal_black.webp',
@@ -1286,7 +1286,7 @@ prevent them from loosening over time.
     }}
     width="1500"
     height="1500"
-    caption="USB socket seal"
+    caption="USB-C socket seal"
   />
 </FlexTableItem>
 

--- a/docs/leo-rover/manuals/main-electronics-box-meb.mdx
+++ b/docs/leo-rover/manuals/main-electronics-box-meb.mdx
@@ -710,14 +710,14 @@ it will destroy the <span style={{color : "#bf7b2c",}} > **seal**</span>.
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="Antenna o-ring"
+    alt="3x1.5 o-ring"
     sources={{
       light: useBaseUrl('/img/robots/leo/manuals/meb/Antenna_oring_black.webp'),
       dark: useBaseUrl('/img/robots/leo/manuals/meb/Antenna_oring_white.webp'),
     }}
     width="1500"
     height="1500"
-    caption="Antenna o-ring"
+    caption="3x1.5 o-ring"
   />
 </FlexTableItem>
 

--- a/docs/leo-rover/manuals/main-electronics-box-meb.mdx
+++ b/docs/leo-rover/manuals/main-electronics-box-meb.mdx
@@ -46,13 +46,14 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
     mobileColumns={2}>
       <ThemedImageZoom
             loading="eager"
-            alt="vaseline"
+            alt="Vaseline"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/tools/vaseline_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/tools/vaseline_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Vaseline'
           />
   </FlexTableItem>
 
@@ -65,13 +66,14 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
 >
   <ThemedImageZoom
     loading="eager"
-    alt="loctite"
+    alt="Loctite 243"
     sources={{
       light: useBaseUrl('/img/robots/leo/manuals/tools/loctite_black.webp'),
       dark: useBaseUrl('/img/robots/leo/manuals/tools/loctite_white.webp'),
     }}
     width="1500"
     height="1500"
+    caption="Loctite 243"
   />
 </FlexTableItem>
 
@@ -84,13 +86,14 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
 >
   <ThemedImageZoom
     loading="eager"
-    alt="loctite"
+    alt="Flat Screwdriver"
     sources={{
       light: useBaseUrl('/img/robots/leo/manuals/tools/screwdriver_black.webp'),
       dark: useBaseUrl('/img/robots/leo/manuals/tools/screwdriver_white.webp'),
     }}
     width="1500"
     height="1500"
+    caption='Flat Screwdriver'
   />
 </FlexTableItem>
 </FlexTable>
@@ -134,13 +137,14 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="RPi"
+            alt="Raspberry pi 5"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/meb/RPI_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/meb/RPI_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Raspberry pi 5'
           />
   </FlexTableItem>
 
@@ -193,22 +197,6 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
 ## Step 2
 
 <FlexTable style={{ alignContent: 'center', justifyContent: 'space-evenly'}}>
-  
-  <FlexTableItem
-    style={{
-      width: '30%'
-    }}
-    mobileColumns={2}>
-      <ThemedImageZoom
-            alt="Raspberry pi"
-            sources={{
-              light: useBaseUrl('/img/robots/leo/manuals/meb/RPI_black.webp'),
-              dark: useBaseUrl('/img/robots/leo/manuals/meb/RPI_white.webp'),
-            }}
-            width="1500"
-            height="1500"
-          />
-  </FlexTableItem>
 
 <FlexTableItem
   style={{
@@ -277,22 +265,6 @@ down on the <span style={{ color: '#bf7b2c' }}> **connector handle**</span>.
 ## Step 3
 
 <FlexTable style={{ alignContent: 'center', justifyContent: 'space-evenly'}}>
-  
-  <FlexTableItem
-    style={{
-      width: '30%'
-    }}
-    mobileColumns={2}>
-      <ThemedImageZoom
-            alt="Raspberry pi with camera ribbon"
-            sources={{
-              light: useBaseUrl('/img/robots/leo/manuals/meb/RPI_with_ribbon_black.webp'),
-              dark: useBaseUrl('/img/robots/leo/manuals/meb/RPI_with_ribbon_white.webp'),
-            }}
-            width="1500"
-            height="1500"
-          />
-  </FlexTableItem>
 
 <FlexTableItem
   style={{
@@ -302,13 +274,14 @@ down on the <span style={{ color: '#bf7b2c' }}> **connector handle**</span>.
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="RPI case top"
+    alt="Raspberry Pi case top"
     sources={{
       light: useBaseUrl('/img/robots/leo/manuals/meb/Case_top_black.webp'),
       dark: useBaseUrl('/img/robots/leo/manuals/meb/Case_top_white.webp'),
     }}
     width="1500"
     height="1500"
+    caption="Raspberry Pi case top"
   />
 </FlexTableItem>
 
@@ -318,13 +291,14 @@ down on the <span style={{ color: '#bf7b2c' }}> **connector handle**</span>.
       width: '30%'
     }}mobileColumns={2}>
       <ThemedImageZoom
-            alt="RPI case bottom"
+            alt="Rasperry Pi case bottom"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/meb/Case_bottom_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/meb/Case_bottom_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Raspberry Pi case bottom'
           />
 
   </FlexTableItem>
@@ -381,6 +355,7 @@ Remove tape from heatpads before closing the case.
             }}
             width="1500"
             height="1500"
+            caption='Leo Core'
           />
   </FlexTableItem>
 
@@ -423,7 +398,7 @@ Remove tape from heatpads before closing the case.
 </FlexTable>
 
 <ThemedImageZoom
-  alt="Attaching wifi adapter"
+  alt="Attaching LeoCore"
   sources={{
     light: useBaseUrl('/img/robots/leo/manuals/meb/A_leo_core_black.webp'),
     dark: useBaseUrl('/img/robots/leo/manuals/meb/A_leo_core_white.webp'),
@@ -436,7 +411,7 @@ Remove tape from heatpads before closing the case.
 />
 
 <ThemedImageZoom
-  alt="Attached wifi adapter"
+  alt="Attached LeoCore"
   sources={{
     light: useBaseUrl('/img/robots/leo/manuals/meb/D_leo_core_black.webp'),
     dark: useBaseUrl('/img/robots/leo/manuals/meb/D_leo_core_white.webp'),
@@ -460,13 +435,14 @@ Remove tape from heatpads before closing the case.
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Top metal plate"
+            alt="MEB top metal plate"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/meb/top_metal_plate_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/meb/top_metal_plate_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='MEB top metal plate'
           />
   </FlexTableItem>
 
@@ -478,13 +454,14 @@ Remove tape from heatpads before closing the case.
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="rpi metal plate"
+    alt="MEB Raspberry Pi mount"
     sources={{
       light: useBaseUrl('/img/robots/leo/manuals/meb/rpi_metal_black.webp'),
       dark: useBaseUrl('/img/robots/leo/manuals/meb/rpi_metal_white.webp'),
     }}
     width="1500"
     height="1500"
+    caption="MEB Raspberry Pi mount"
   />
 </FlexTableItem>
 
@@ -570,13 +547,14 @@ it will destroy the <span style={{color : "#bf7b2c",}} > **seal**</span>.
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Raspberry pi in a case"
+            alt="Step 4 assembly"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/meb/rpi_in_case_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/meb/rpi_in_case_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Step 4 assembly'
           />
   </FlexTableItem>
 
@@ -645,6 +623,7 @@ it will destroy the <span style={{color : "#bf7b2c",}} > **seal**</span>.
             }}
             width="1500"
             height="1500"
+            caption='Alfa wifi adapter'
           />
   </FlexTableItem>
 
@@ -656,7 +635,7 @@ it will destroy the <span style={{color : "#bf7b2c",}} > **seal**</span>.
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="Antenna 90 deg adapter"
+    alt="90deg RP-SMA to SMA adapter"
     sources={{
       light: useBaseUrl(
         '/img/robots/leo/manuals/meb/90deg_antenna_adapter_black.webp',
@@ -667,6 +646,7 @@ it will destroy the <span style={{color : "#bf7b2c",}} > **seal**</span>.
     }}
     width="1500"
     height="1500"
+    caption="90deg RP-SMA to SMA adapter"
   />
 </FlexTableItem>
 
@@ -717,6 +697,7 @@ it will destroy the <span style={{color : "#bf7b2c",}} > **seal**</span>.
             }}
             width="1500"
             height="1500"
+            caption='Antenna cable'
           />
   </FlexTableItem>
 
@@ -753,6 +734,7 @@ it will destroy the <span style={{color : "#bf7b2c",}} > **seal**</span>.
             }}
             width="1500"
             height="1500"
+            caption='Vaseline'
           />
 
   </FlexTableItem>
@@ -812,6 +794,7 @@ can easily be crushed.
       }}
       width="1500"
       height="1500"
+      caption="USB AM-CM cable"
     />
   </FlexTableItem>
 </FlexTable>
@@ -854,13 +837,14 @@ can easily be crushed.
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Camera"
+            alt="Arducam camera"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/meb/camera_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/meb/camera_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Arducam camera'
           />
   </FlexTableItem>
 
@@ -879,6 +863,7 @@ can easily be crushed.
     }}
     width="1500"
     height="1500"
+    caption="Camera holder"
   />
 </FlexTableItem>
 
@@ -1013,13 +998,14 @@ can easily be crushed.
     }}
     mobileColumns={2}>
       <ThemedImageZoom
-            alt="Camera assembly"
+            alt="Step 10 assembly"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/meb/camera_assembly_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/meb/camera_assembly_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Step 10 assembly'
           />
   </FlexTableItem>
 
@@ -1097,6 +1083,7 @@ can easily be crushed.
       }}
       width="1500"
       height="1500"
+      caption="MEB power cable"
     />
   </FlexTableItem>
 </FlexTable>
@@ -1154,6 +1141,7 @@ can easily be crushed.
             }}
             width="1500"
             height="1500"
+            caption='Step 9 assembly'
           />
   </FlexTableItem>
 
@@ -1165,7 +1153,7 @@ can easily be crushed.
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="Top cover seal"
+    alt="MEB top cover seal"
     sources={{
       light: useBaseUrl(
         '/img/robots/leo/manuals/meb/Top_cover_seal_black.webp',
@@ -1174,6 +1162,7 @@ can easily be crushed.
     }}
     width="1500"
     height="1500"
+    caption="MEB top cover seal"
   />
 </FlexTableItem>
 
@@ -1208,6 +1197,7 @@ can easily be crushed.
             }}
             width="1500"
             height="1500"
+            caption='Loctite 243'
           />
 
   </FlexTableItem>
@@ -1273,6 +1263,7 @@ prevent them from loosening over time.
             }}
             width="1500"
             height="1500"
+            caption='USB-C socket'
           />
   </FlexTableItem>
 
@@ -1295,6 +1286,7 @@ prevent them from loosening over time.
     }}
     width="1500"
     height="1500"
+    caption="USB socket seal"
   />
 </FlexTableItem>
 

--- a/docs/leo-rover/manuals/setup.mdx
+++ b/docs/leo-rover/manuals/setup.mdx
@@ -35,7 +35,7 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
   
   <FlexTableItem
     style={{
-      width: '40%'
+      width: '30%'
     }}
     mobileColumns={2}>
       <ThemedImageZoom
@@ -54,7 +54,7 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
 <FlexTableItem
   style={{
     textAlign: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -74,7 +74,7 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
     <FlexTableItem
     style={{
       textAlign: 'center',
-      width: '40%'
+      width: '30%'
     }}mobileColumns={2}>
       <ThemedImageZoom
             alt="Flat screwdriver"
@@ -92,7 +92,7 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
    <FlexTableItem
     style={{
       textAlign: 'center',
-      width: '40%'
+      width: '30%'
     }}mobileColumns={2}>
       <ThemedImageZoom
             alt="Vaseline"
@@ -155,7 +155,7 @@ information is provided in boxes like this one, located below the images.
   
   <FlexTableItem
     style={{
-      width: '40%',
+      width: '30%',
     }}
     mobileColumns={2}>
       <ThemedImageZoom
@@ -173,7 +173,7 @@ information is provided in boxes like this one, located below the images.
   style={{
     textAlign: 'center',
     alignContent: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -184,7 +184,7 @@ information is provided in boxes like this one, located below the images.
     <FlexTableItem
     style={{
       textAlign: 'center',
-      width: '40%',
+      width: '30%',
     }}mobileColumns={2}>
       <ThemedImageZoom
             alt="Seal OK"
@@ -202,7 +202,7 @@ information is provided in boxes like this one, located below the images.
     style={{
       textAlign: 'center',
       alignContent: 'center',
-      width: '40%',
+      width: '30%',
     }}mobileColumns={2}>
       <span style={{color : "green", fontSize : "700%"}} >**OK**</span>
   </FlexTableItem>

--- a/docs/leo-rover/manuals/setup.mdx
+++ b/docs/leo-rover/manuals/setup.mdx
@@ -45,8 +45,8 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
               light: useBaseUrl('/img/robots/leo/manuals/tools/grease_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/tools/grease_white.webp'),
             }}
-            width="2300"
-            height="2400"
+            width="1500"
+            height="1500"
             caption='Lithium grease'
           />
   </FlexTableItem>
@@ -65,8 +65,8 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
       light: useBaseUrl('/img/robots/leo/manuals/tools/loctite_black.webp'),
       dark: useBaseUrl('/img/robots/leo/manuals/tools/loctite_white.webp'),
     }}
-    width="2300"
-    height="2400"
+    width="1500"
+    height="1500"
     caption="Loctite 243"
   />
 </FlexTableItem>
@@ -82,8 +82,8 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
               light: useBaseUrl('/img/robots/leo/manuals/tools/screwdriver_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/tools/screwdriver_white.webp'),
             }}
-            width="2300"
-            height="2400"
+            width="1500"
+            height="1500"
             caption='Flat screwdriver'
           />
 
@@ -100,8 +100,8 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
               light: useBaseUrl('/img/robots/leo/manuals/tools/vaseline_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/tools/vaseline_white.webp'),
             }}
-            width="2300"
-            height="2400"
+            width="1500"
+            height="1500"
             caption='Vaseline'
           />
   </FlexTableItem>
@@ -138,8 +138,8 @@ groove.
     light: useBaseUrl('/img/robots/leo/manuals/tools/note_1.9_black.webp'),
     dark: useBaseUrl('/img/robots/leo/manuals/tools/note_1.9_white.webp'),
   }}
-  width="2787"
-  height="2000"
+  width="3000"
+  height="2121"
 />
 
 :::note

--- a/docs/leo-rover/manuals/setup.mdx
+++ b/docs/leo-rover/manuals/setup.mdx
@@ -40,13 +40,14 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
     mobileColumns={2}>
       <ThemedImageZoom
             loading="eager"
-            alt="grease"
+            alt="Lithium grease"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/tools/grease_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/tools/grease_white.webp'),
             }}
             width="2300"
             height="2400"
+            caption='Lithium grease'
           />
   </FlexTableItem>
 
@@ -59,13 +60,14 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
 >
   <ThemedImageZoom
     loading="eager"
-    alt="loctite"
+    alt="Loctite 243"
     sources={{
       light: useBaseUrl('/img/robots/leo/manuals/tools/loctite_black.webp'),
       dark: useBaseUrl('/img/robots/leo/manuals/tools/loctite_white.webp'),
     }}
     width="2300"
     height="2400"
+    caption="Loctite 243"
   />
 </FlexTableItem>
 
@@ -75,13 +77,14 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
       width: '40%'
     }}mobileColumns={2}>
       <ThemedImageZoom
-            alt="screwdriver"
+            alt="Flat screwdriver"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/tools/screwdriver_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/tools/screwdriver_white.webp'),
             }}
             width="2300"
             height="2400"
+            caption='Flat screwdriver'
           />
 
   </FlexTableItem>
@@ -92,13 +95,14 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
       width: '40%'
     }}mobileColumns={2}>
       <ThemedImageZoom
-            alt="vaseline"
+            alt="Vaseline"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/tools/vaseline_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/tools/vaseline_white.webp'),
             }}
             width="2300"
             height="2400"
+            caption='Vaseline'
           />
   </FlexTableItem>
 </FlexTable>
@@ -118,9 +122,13 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
   height="2400"
 />
 
+:::note
+
 When attaching <span style={{color : "#bf7b2c",}} > **T-nuts** </span> at any
 point during the assembly, ensure both sides are seated on the flanges of the
 groove.
+
+:::
 
 ### Notes
 
@@ -142,9 +150,6 @@ information is provided in boxes like this one, located below the images.
 :::
 
 ### Seals
-
-Ensure all seals are<span style={{color : "#bf7b2c",}} > **properly
-aligned**</span>.
 
 <FlexTable style={{ alignContent: 'center', justifyContent: 'space-evenly'}}>
   
@@ -203,12 +208,23 @@ aligned**</span>.
   </FlexTableItem>
 </FlexTable>
 
+:::note
+
+Ensure all seals are<span style={{color : "#bf7b2c",}} > **properly
+aligned**</span>.
+
+:::
+
 ### Wires
 
-No tools are provided for tightening the panel mount sockets the sides of
+:::note
+
+No tools are provided for tightening the panel mount sockets to the sides of
 electronics box or battery.\
 Panel socket nuts should be hand-tight only, as excessive force can damage the
 seals.
+
+:::
 
 :::warning
 

--- a/docs/leo-rover/manuals/wheel-assembly.mdx
+++ b/docs/leo-rover/manuals/wheel-assembly.mdx
@@ -38,7 +38,7 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
   
   <FlexTableItem
     style={{
-      width: '40%'
+      width: '30%'
     }}
     mobileColumns={2}>
       <ThemedImageZoom
@@ -56,7 +56,7 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
    
   <FlexTableItem
     style={{
-      width: '40%'
+      width: '30%'
     }}
     mobileColumns={2}>
       <ThemedImageZoom
@@ -94,7 +94,7 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
 <FlexTable style={{ alignContent: 'center', justifyContent: 'space-evenly'}}>
     <FlexTableItem
     style={{
-      width: '40%'
+      width: '30%'
     }}
     mobileColumns={2}>
       <ThemedImageZoom
@@ -111,7 +111,7 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
 
 <FlexTableItem
   style={{
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -165,7 +165,7 @@ style={{color : "#bf7b2c",}} > **seal** </span> and the motor housing.
 <FlexTableItem
   style={{
     textAlign: 'center',
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -184,7 +184,7 @@ style={{color : "#bf7b2c",}} > **seal** </span> and the motor housing.
     <FlexTableItem
     style={{
       textAlign: 'center',
-      width: '40%'
+      width: '30%'
     }}mobileColumns={2}>
       <ThemedImageZoom
             alt="Set screw M5"
@@ -202,7 +202,7 @@ style={{color : "#bf7b2c",}} > **seal** </span> and the motor housing.
   <FlexTableItem
     style={{
       textAlign: 'center',
-      width: '40%'
+      width: '30%'
     }}mobileColumns={2}>
       <ThemedImageZoom
             alt="Loctite 243"
@@ -263,7 +263,7 @@ screw**</span>. Use a drop of loctite to make sure it stays in place.
   
 <FlexTableItem
   style={{
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -281,7 +281,7 @@ screw**</span>. Use a drop of loctite to make sure it stays in place.
 
 <FlexTableItem
   style={{
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -343,7 +343,7 @@ until it touches the base of the bearing before tightening.
 
 <FlexTableItem
   style={{
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >
@@ -361,7 +361,7 @@ until it touches the base of the bearing before tightening.
 
     <FlexTableItem
     style={{
-      width: '40%'
+      width: '30%'
     }}
     mobileColumns={2}>
       <ThemedImageZoom
@@ -379,7 +379,7 @@ until it touches the base of the bearing before tightening.
 
 <FlexTableItem
   style={{
-    width: '40%',
+    width: '30%',
   }}
   mobileColumns={2}
 >

--- a/docs/leo-rover/manuals/wheel-assembly.mdx
+++ b/docs/leo-rover/manuals/wheel-assembly.mdx
@@ -27,8 +27,8 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
       '/img/robots/leo/manuals/tools/toolbox_1.9_wheel_white.webp',
     ),
   }}
-  width="1480"
-  height="2200"
+  width="3000"
+  height="2121"
   figStyle={{
     width: 600,
   }}
@@ -43,13 +43,14 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
     mobileColumns={2}>
       <ThemedImageZoom
             loading="eager"
-            alt="Grease"
+            alt="Lithium grease"
             sources={{
-              light: useBaseUrl('/img/robots/leo/manuals/tools/loctite_black.webp'),
-              dark: useBaseUrl('/img/robots/leo/manuals/tools/loctite_white.webp'),
+              light: useBaseUrl('/img/robots/leo/manuals/tools/grease_black.webp'),
+              dark: useBaseUrl('/img/robots/leo/manuals/tools/grease_white.webp'),
             }}
             width="2300"
             height="2400"
+            caption='Lithium grease'
           />
   </FlexTableItem>
    
@@ -60,13 +61,14 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
     mobileColumns={2}>
       <ThemedImageZoom
             loading="eager"
-            alt="loctite"
+            alt="Loctite 243"
             sources={{
-              light: useBaseUrl('/img/robots/leo/manuals/tools/grease_black.webp'),
-              dark: useBaseUrl('/img/robots/leo/manuals/tools/grease_white.webp'),
+              light: useBaseUrl('/img/robots/leo/manuals/tools/loctite_black.webp'),
+              dark: useBaseUrl('/img/robots/leo/manuals/tools/loctite_white.webp'),
             }}
             width="2300"
             height="2400"
+            caption='Loctite 243'
           />
 
   </FlexTableItem>
@@ -103,6 +105,7 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
             }}
             width="1500"
             height="1500"
+            caption='Lithium grease'
           />
   </FlexTableItem>
 
@@ -113,20 +116,21 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="Motor"
+    alt="Leo Rover Motor"
     sources={{
       light: useBaseUrl('/img/robots/leo/manuals/wheel/motor_black.webp'),
       dark: useBaseUrl('/img/robots/leo/manuals/wheel/motor_white.webp'),
     }}
     width="1500"
     height="1500"
+    caption="Leo Rover Motor"
   />
 </FlexTableItem>
 
 </FlexTable>
 
 <ThemedImageZoom
-  alt="Step 3 - 1"
+  alt="Applying lithium grease"
   sources={{
     light: useBaseUrl('/img/robots/leo/manuals/wheel/A_grease_black.webp'),
     dark: useBaseUrl('/img/robots/leo/manuals/wheel/A_grease_white.webp'),
@@ -166,13 +170,14 @@ style={{color : "#bf7b2c",}} > **seal** </span> and the motor housing.
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="shaft adapter"
+    alt="Shaft adapter"
     sources={{
       light: useBaseUrl('/img/robots/leo/manuals/wheel/shaft_black.webp'),
       dark: useBaseUrl('/img/robots/leo/manuals/wheel/shaft_white.webp'),
     }}
     width="1500"
     height="1500"
+    caption="Shaft adapter"
   />
 </FlexTableItem>
 
@@ -182,14 +187,14 @@ style={{color : "#bf7b2c",}} > **seal** </span> and the motor housing.
       width: '40%'
     }}mobileColumns={2}>
       <ThemedImageZoom
-            alt="Set Screw M5"
+            alt="Set screw M5"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/wheel/headless_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/wheel/headless_white.webp'),
             }}
             width="1500"
             height="1500"
-            caption="Set Screw M5"
+            caption="Set screw M5"
           />
 
   </FlexTableItem>
@@ -200,13 +205,14 @@ style={{color : "#bf7b2c",}} > **seal** </span> and the motor housing.
       width: '40%'
     }}mobileColumns={2}>
       <ThemedImageZoom
-            alt="loctite"
+            alt="Loctite 243"
             sources={{
               light: useBaseUrl('/img/robots/leo/manuals/tools/loctite_black.webp'),
               dark: useBaseUrl('/img/robots/leo/manuals/tools/loctite_white.webp'),
             }}
             width="1500"
             height="1500"
+            caption='Loctite 243'
           />
 
   </FlexTableItem>
@@ -269,6 +275,7 @@ screw**</span>. Use a drop of loctite to make sure it stays in place.
     }}
     width="1500"
     height="1500"
+    caption='Motor mount'
   />
 </FlexTableItem>
 
@@ -323,7 +330,7 @@ until it touches the base of the bearing before tightening.
     ),
   }}
   width="3000"
-  height="1060"
+  height="2121"
   figStyle={{
     width: 600,
   }}
@@ -341,13 +348,14 @@ until it touches the base of the bearing before tightening.
   mobileColumns={2}
 >
   <ThemedImageZoom
-    alt="Wheel"
+    alt="Tire with rim"
     sources={{
       light: useBaseUrl('/img/robots/leo/manuals/wheel/Rim_black.webp'),
       dark: useBaseUrl('/img/robots/leo/manuals/wheel/Rim_white.webp'),
     }}
     width="1500"
     height="1500"
+    caption="Tire with rim"
   />
 </FlexTableItem>
 
@@ -364,6 +372,7 @@ until it touches the base of the bearing before tightening.
             }}
             width="1500"
             height="1500"
+            caption='Torque plate'
           />
 
   </FlexTableItem>
@@ -389,26 +398,26 @@ until it touches the base of the bearing before tightening.
 </FlexTable>
 
 <ThemedImageZoom
-  alt="6 - 2"
+  alt="Attaching wheel to motor"
   sources={{
     light: useBaseUrl('/img/robots/leo/manuals/wheel/A_rim_black.webp'),
     dark: useBaseUrl('/img/robots/leo/manuals/wheel/A_rim_white.webp'),
   }}
   width="3000"
-  height="2200"
+  height="2121"
   figStyle={{
     width: 600,
   }}
 />
 
 <ThemedImageZoom
-  alt="6 - 2"
+  alt="Attached wheel"
   sources={{
     light: useBaseUrl('/img/robots/leo/manuals/wheel/F_rim_black.webp'),
     dark: useBaseUrl('/img/robots/leo/manuals/wheel/F_rim_white.webp'),
   }}
   width="3000"
-  height="2200"
+  height="2121"
   figStyle={{
     width: 600,
   }}


### PR DESCRIPTION
Added a captions to all part images in assembly manuals - so people can reference parts for replacement etc.
Fixed a bunch of problems with image sizes, minor text misspelling/missing words.