### PR TITLE
content: Fix file names in lidar integration tutorials

### DIFF
--- a/docs/integrations/lidars/hokuyo-ug-04lx-ug01.mdx
+++ b/docs/integrations/lidars/hokuyo-ug-04lx-ug01.mdx
@@ -168,7 +168,7 @@ start at boot.
 Your robot should be aware of where the scanner is located and what space it
 occupies. You can ensure it does that by creating a URDF model of the sensor.
 
-```xml title="/etc/ros/urdf/laser.urdf.xacro"
+```xml title="/etc/ros/urdf/laser.urdf"
 <?xml version="1.0"?>
 <robot>
 
@@ -225,7 +225,7 @@ occupies. You can ensure it does that by creating a URDF model of the sensor.
 And including it in the description that is uploaded at boot.
 
 ```xml title="/etc/ros/urdf/robot.urdf.xacro"
-<xacro:include filename="/etc/ros/urdf/laser.urdf.xacro"/>
+<xacro:include filename="/etc/ros/urdf/laser.urdf"/>
 ```
 
 :::tip

--- a/docs/integrations/lidars/slamtec-rplidar-s3.mdx
+++ b/docs/integrations/lidars/slamtec-rplidar-s3.mdx
@@ -242,7 +242,7 @@ occupies. You can ensure it does that by creating a URDF model of the sensor.
 And including it in the description that is uploaded at boot.
 
 ```xml title="/etc/ros/urdf/robot.urdf.xacro"
-<xacro:include filename="/etc/ros/urdf/laser.urdf.xacro"/>
+<xacro:include filename="/etc/ros/urdf/laser.urdf"/>
 ```
 
 :::tip


### PR DESCRIPTION
There was an error in the lidar S3 integration tutorial - our tutorial was guiding users to include in the `robot.urdf.xacro` file non-existing file.