### PR TITLE
fix: Update system service node names in ROS API documentation

### DIFF
--- a/docs/raph-rover/documentation/ros-api.mdx
+++ b/docs/raph-rover/documentation/ros-api.mdx
@@ -184,8 +184,8 @@ image: /img/robots/raph/raph-rover.webp
 
   Perform onboard computer's system shutdown.
 
-- `raph_system/reboot` ([std_srvs/srv/Trigger])
-  Perform onboard computer's system reboot.
+- `raph_system/reboot` ([std_srvs/srv/Trigger]) Perform onboard computer's
+  system reboot.
 
 ## Parameters
 

--- a/docs/raph-rover/documentation/ros-api.mdx
+++ b/docs/raph-rover/documentation/ros-api.mdx
@@ -180,12 +180,11 @@ image: /img/robots/raph/raph-rover.webp
 
   Set the current steering mode.
 
-- `system/shutdown` ([std_srvs/srv/Trigger])
+- `raph_system/shutdown` ([std_srvs/srv/Trigger])
 
   Perform onboard computer's system shutdown.
 
-- `system/reboot` ([std_srvs/srv/Trigger])
-
+- `raph_system/reboot` ([std_srvs/srv/Trigger])
   Perform onboard computer's system reboot.
 
 ## Parameters

--- a/docs/raph-rover/documentation/ros-api.mdx
+++ b/docs/raph-rover/documentation/ros-api.mdx
@@ -184,8 +184,9 @@ image: /img/robots/raph/raph-rover.webp
 
   Perform onboard computer's system shutdown.
 
-- `raph_system/reboot` ([std_srvs/srv/Trigger]) Perform onboard computer's
-  system reboot.
+- `raph_system/reboot` ([std_srvs/srv/Trigger])
+
+  Perform onboard computer's system reboot.
 
 ## Parameters
 


### PR DESCRIPTION
Correct the names of system service nodes in the ROS API documentation to reflect the proper naming conventions.