### PR TITLE
Fix: Step numbering in wheel assembly manual

### DIFF
--- a/docs/leo-rover/manuals/wheel-assembly.mdx
+++ b/docs/leo-rover/manuals/wheel-assembly.mdx
@@ -267,7 +267,7 @@ screw**</span>. Use a drop of loctite to make sure it stays in place.
   }}
 />
 
-## Step 2
+## Step 3
 
 <FlexTable style={{ alignContent: 'center', justifyContent: 'space-evenly'}}>
   


### PR DESCRIPTION
Correct the step numbering in the wheel assembly manual to ensure clarity and accuracy.