### PR TITLE
Content/leo assembly vaseline

### DIFF
--- a/docs/leo-rover/manuals/main-electronics-box-meb.mdx
+++ b/docs/leo-rover/manuals/main-electronics-box-meb.mdx
@@ -48,24 +48,6 @@ import FlexTableItem from '@site/src/components/FlexTableItem';
 />
 
 <FlexTable style={{ alignContent: 'center', justifyContent: 'space-evenly'}}>
-  
-  <FlexTableItem
-    style={{
-      width: '30%'
-    }}
-    mobileColumns={2}>
-      <ThemedImageZoom
-            loading="eager"
-            alt="Vaseline"
-            sources={{
-              light: useBaseUrl('/img/robots/leo/manuals/tools/vaseline_black.webp'),
-              dark: useBaseUrl('/img/robots/leo/manuals/tools/vaseline_white.webp'),
-            }}
-            width="1500"
-            height="1500"
-            caption='Vaseline'
-          />
-  </FlexTableItem>
 
 <FlexTableItem
   style={{
@@ -730,24 +712,6 @@ it will destroy the <span style={{color : "#bf7b2c",}} > **seal**</span>.
     caption="3x1.5 o-ring"
   />
 </FlexTableItem>
-
-    <FlexTableItem
-    style={{
-      width: '30%'
-    }}
-    mobileColumns={2}>
-      <ThemedImageZoom
-            alt="Vaseline"
-            sources={{
-              light: useBaseUrl('/img/robots/leo/manuals/tools/vaseline_black.webp'),
-              dark: useBaseUrl('/img/robots/leo/manuals/tools/vaseline_white.webp'),
-            }}
-            width="1500"
-            height="1500"
-            caption='Vaseline'
-          />
-
-  </FlexTableItem>
 </FlexTable>
 
 <ThemedImageZoom
@@ -765,8 +729,6 @@ it will destroy the <span style={{color : "#bf7b2c",}} > **seal**</span>.
 
 :::note
 
-Cover the <span style={{color : "#bf7b2c",}} > **seal** </span> with vaseline
-before assembly.\
 Do not overtighten as the <span style={{color : "#bf7b2c",}} > **seal**</span>
 can easily be crushed.
 

--- a/docs/leo-rover/manuals/setup.mdx
+++ b/docs/leo-rover/manuals/setup.mdx
@@ -99,23 +99,6 @@ import ThemedImageZoom from '@site/src/components/ThemedImageZoom';
           />
 
   </FlexTableItem>
-
-   <FlexTableItem
-    style={{
-      textAlign: 'center',
-      width: '30%'
-    }}mobileColumns={2}>
-      <ThemedImageZoom
-            alt="Vaseline"
-            sources={{
-              light: useBaseUrl('/img/robots/leo/manuals/tools/vaseline_black.webp'),
-              dark: useBaseUrl('/img/robots/leo/manuals/tools/vaseline_white.webp'),
-            }}
-            width="1500"
-            height="1500"
-            caption='Vaseline'
-          />
-  </FlexTableItem>
 </FlexTable>
 ---
 

--- a/docs/raph-rover/documentation/user-manual/control-and-basic-operations.mdx
+++ b/docs/raph-rover/documentation/user-manual/control-and-basic-operations.mdx
@@ -42,8 +42,8 @@ The table below describes rover's network configuration:
 
 | Device       | IP Address or hostname     | Description                                                                                                                                                                 |
 | ------------ | :------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Router       | `10.0.0.1`                 | The built-in router providing Wi-Fi access point.                                                                                                                           |
-| UPBoard 7000 | `10.0.0.2` or `raph.local` | The built-in computer running ROS and other software components. Uses mDNS for hostname resolution.                                                                         |
+| Router       | `10.10.0.1`                 | The built-in router providing Wi-Fi access point.                                                                                                                           |
+| UPBoard 7000 | `10.10.0.2` or `raph.local` | The built-in computer running ROS and other software components. Uses mDNS for hostname resolution.                                                                         |
 | RaphCore     | `raphcore.local`           | The microcontroller managing low-level hardware functions. Its IP address is not consistent across the rovers but can be accessed via mDNS under the name `raphcore.local`. |
 
 You can learn how to connect the Raph Rover to an existing Wi-Fi network or

--- a/docs/raph-rover/documentation/user-manual/control-and-basic-operations.mdx
+++ b/docs/raph-rover/documentation/user-manual/control-and-basic-operations.mdx
@@ -40,11 +40,11 @@ To learn how to connect to the Raph Rover's Access Point, follow guide below:
 
 The table below describes rover's network configuration:
 
-| Device       | IP Address or hostname     | Description                                                                                                                                                                 |
-| ------------ | :------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Device       | IP Address or hostname      | Description                                                                                                                                                                 |
+| ------------ | :-------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Router       | `10.10.0.1`                 | The built-in router providing Wi-Fi access point.                                                                                                                           |
 | UPBoard 7000 | `10.10.0.2` or `raph.local` | The built-in computer running ROS and other software components. Uses mDNS for hostname resolution.                                                                         |
-| RaphCore     | `raphcore.local`           | The microcontroller managing low-level hardware functions. Its IP address is not consistent across the rovers but can be accessed via mDNS under the name `raphcore.local`. |
+| RaphCore     | `raphcore.local`            | The microcontroller managing low-level hardware functions. Its IP address is not consistent across the rovers but can be accessed via mDNS under the name `raphcore.local`. |
 
 You can learn how to connect the Raph Rover to an existing Wi-Fi network or
 configure network settings in the guides below:


### PR DESCRIPTION
Vaseline has been used in Leo Rover 1.8 in just one step of the assembly.
In Leo Rover 1.9 it is still being used in the same single point. 

In general - it makes no real difference whether we use or not, so it was removed from the Dev kit. 
We need to adjust the manual in the right moment - before we send the first rovers with no vaseline 