### PR TITLE
chore: Add redirect from generation robots' website link

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -85,3 +85,5 @@
 # Addon redirects - we only keep the latest version of the addon documentation, so we redirect all older versions to the latest one
 /leo-rover/1.8/addons/high-capacity-battery /leo-rover/addons/high-capacity-battery 301
 
+# Generation Robots redirect - they have this link on their website pointing to this URL
+/assembly-manuals/check-the-boxes /leo-rover/manuals 301


### PR DESCRIPTION
Generation Robots have this link on their website and its faster to make a redirect for now. We will delete it after link correction.